### PR TITLE
Device Attestation vs. Device Assignment

### DIFF
--- a/draft-poirier-rats-eat-da.md
+++ b/draft-poirier-rats-eat-da.md
@@ -83,7 +83,7 @@ This list is by no means exhaustive and is expected to expand.
 
 # Device Assignment Token (DAT) Claims
 
-The Device Attestation Token (DAT) is the encompassing envelope for the individual device claims to be presented.
+The Device Assignment Token (DAT) is the encompassing envelope for the individual device claims to be presented.
 A DAT can be used as a standalone entity but can also be embedded in a larger, platform-specific attestation token.
 A DAT consists of an EAT profile identifier, a nonce and an EAT submodule ({{Section 4.2.18 of -rats-eat}}) that contains any number of individual device claims.
 Each individual device claim is the combination of a device name and a standard claims format based on the bus or protocol the device supports.


### PR DESCRIPTION
The overload of the DA acronym is confusing and probably unnecessary.
This PR is intended to act as a basis for discussion.